### PR TITLE
Feature: Allow creating icons from drawable resources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,3 +44,5 @@ publishRepoIssues=https://github.com/maltaisn/icondialoglib/issues
 publishLicense=Apache-2.0
 publishLicenseName=The Apache Software License, Version 2.0
 publishLicenseUrl=http://www.apache.org/licenses/LICENSE-2.0.txt
+
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Wed Jul 03 17:26:26 CEST 2019
+#Wed Feb 12 19:24:26 WAT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip
+

--- a/lib/src/main/kotlin/com/maltaisn/icondialog/IconDialog.kt
+++ b/lib/src/main/kotlin/com/maltaisn/icondialog/IconDialog.kt
@@ -21,8 +21,8 @@ import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Color
-import android.graphics.PorterDuff
 import android.graphics.Rect
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Handler
 import android.view.LayoutInflater
@@ -35,7 +35,9 @@ import android.widget.*
 import androidx.annotation.ColorRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.content.res.use
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.os.ConfigurationCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
@@ -99,6 +101,7 @@ class IconDialog : DialogFragment(), IconDialogContract.View {
     private var iconSize = 0
     private var iconColorNormal = Color.BLACK
     private var iconColorSelected = Color.BLACK
+    private lateinit var unavailableIconDrawable: Drawable
 
 
     @SuppressLint("InflateParams", "Recycle")
@@ -110,6 +113,7 @@ class IconDialog : DialogFragment(), IconDialogContract.View {
         }
         val contextWrapper = ContextThemeWrapper(context, style)
         val localInflater = LayoutInflater.from(contextWrapper)
+        unavailableIconDrawable = ResourcesCompat.getDrawable(context.resources, R.drawable.icd_ic_unavailable, null)!!
 
         // Get style attributes values
         contextWrapper.obtainStyledAttributes(R.styleable.IconDialog).use {
@@ -368,16 +372,14 @@ class IconDialog : DialogFragment(), IconDialogContract.View {
             }
 
             override fun bindView(icon: Icon, selected: Boolean) {
-                val drawable = icon.drawable
-                if (drawable != null) {
-                    iconImv.setImageDrawable(drawable.mutate())
+                val drawable = DrawableCompat.wrap(icon.drawable ?: unavailableIconDrawable).mutate()
+                iconImv.setImageDrawable(drawable)
+                DrawableCompat.setTint(drawable, if (selected) iconColorSelected else iconColorNormal)
+                if (icon.drawable != null) {
                     iconImv.alpha = 1.0f
                 } else {
-                    iconImv.setImageResource(R.drawable.icd_ic_unavailable)
                     iconImv.alpha = 0.3f
                 }
-                iconImv.setColorFilter(if (selected) iconColorSelected else iconColorNormal,
-                        PorterDuff.Mode.SRC_IN)
             }
         }
 

--- a/lib/src/main/kotlin/com/maltaisn/icondialog/data/Icon.kt
+++ b/lib/src/main/kotlin/com/maltaisn/icondialog/data/Icon.kt
@@ -30,7 +30,9 @@ data class Icon(val id: Int,
                 val tags: List<String>,
                 val pathData: String,
                 val width: Int,
-                val height: Int) {
+                val height: Int,
+                val drawableResId: Int? = null
+) {
 
     /**
      * The icon drawable.


### PR DESCRIPTION
#### What does this PR do?
Custom icon packs only allow creating icons by specifying the `path` attribute for `icon` elements. This PR adds functionality that allows specifying drawable resource ids - `drawableResId` in the user project for `icon`s.

#### Usage
```
...
<icon width=".." height=".." id=".." drawableResId="@drawable/custom_icon_drawable_in_your_project" category=".." tags="..."  />
...
```

Closes #29 